### PR TITLE
Some fixes for errors we ran into, we are testing the changes on a few systems now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-makefile
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 makefile
+.gitignore

--- a/Base.pm
+++ b/Base.pm
@@ -613,7 +613,9 @@ sub close {
             $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
             1;
         };
-        warn if $@;
+        # I dont want to add to the excess warnings of perl
+        # so if anyone want to debug then enable the following:
+        # warn if $@;
     }
 
     # Return to illview

--- a/Base.pm
+++ b/Base.pm
@@ -589,7 +589,6 @@ sub close {
 
     # Ill request attributes that should be anonymized
     my @anon_fields = qw(
-        end_user_library_card
         end_user_address
         end_user_approved_by
         end_user_city
@@ -610,7 +609,11 @@ sub close {
         user_id
     );
     foreach my $field ( @anon_fields ) {
-        $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
+        eval {
+            $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
+            1;
+        };
+        warn if $@;
     }
 
     # Return to illview

--- a/Base.pm
+++ b/Base.pm
@@ -30,6 +30,7 @@ use C4::Biblio;
 use C4::Context;
 use C4::Letters;
 use C4::Message;
+use C4::Items;
 use Koha::Illrequestattribute;
 use Koha::Patrons;
 use Koha::Item;


### PR DESCRIPTION
The changes on the systems we are testing on seem to work so far.

We found two problems the resent days.

First problem:
=========
`Undefined subroutine &Koha::Illbackends::Libris::Base::DelItemCheck called at /usr/share/koha/lib/Koha/Illbackends/Libris/Base.pm line 565`
This was solved by changing the following,
`565 DelItemCheck( $item->biblionumber, $item->itemnumber);`
too, I have since instead imported the C4::Items
`C4::Items::DelItemCheck( $item->biblionumber, $item->itemnumber);`
However according to Koha bugs( https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=26992) this DelItemCheck is obsolete and might not exist in newer versions. I have not checked this.


The seccond problem:
================
`Can't call method "update" on an undefined value at /usr/share/koha/lib/Koha/Illbackends/Libris/Base.pm line 612.`
This showed itself to be from missing several of the following key=> values in the database, also end_user_library_card was a duplicate.

```
591         end_user_library_card
 592         -end_user_address
 593         end_user_approved_by
 594         -end_user_city
 595         -end_user_email
 596         -end_user_first_name
 597         end_user_institution
 598         end_user_institution_delivery
 599         end_user_institution_phone
 600         -end_user_last_name
 601         2-end_user_library_card
 602         -end_user_mobile
 603         -end_user_phone
 604         end_user_user_id
 605         -end_user_zip_code
 606         enduser_id
 607         libris_enduser_request_id
 608         user
 609         user_id

```
Ive marked the duplicate 2- and the missing with - in the pull ive only removed the duplicate though.
The librarian would get an error System failure but the post was changed to IN_AVSL but no variables was changed after the error.

I chose to add errorhandling as I dont know if these exist in other circumstances,

`612 $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });`
was changed to this:
```
 611     foreach my $field ( @anon_fields ) {
 612         eval {
 613                 $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
 614                 1;
 615         };

```
It will allow for the fields that do exist to be changed.
