### PR TITLE
Problem when iterating attributes

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -588,7 +588,6 @@ sub close {
 
     # Ill request attributes that should be anonymized
     my @anon_fields = qw(
-        end_user_library_card
         end_user_address
         end_user_approved_by
         end_user_city
@@ -609,8 +608,14 @@ sub close {
         user_id
     );
     foreach my $field ( @anon_fields ) {
-        $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
+        eval {
+            $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
+            1;
+        };
+        #I dont want to add to the excess logging of koha, but if someone want to debug
+        #warn if $@;
     }
+
 
     # Return to illview
     return {


### PR DESCRIPTION
`Can't call method "update" on an undefined value at /usr/share/koha/lib/Koha/Illbackends/Libris/Base.pm line 612.`

This error was cased by missing fields in the database. I have marked the missing fields bellow, but I have not removed 
them as they might be used when existing.

`
 591         end_user_library_card
 592         -end_user_address
 593         end_user_approved_by
 594         -end_user_city
 595         -end_user_email
 596         -end_user_first_name
 597         end_user_institution
 598         end_user_institution_delivery
 599         end_user_institution_phone
 600         -end_user_last_name
 601         2-end_user_library_card
 602         -end_user_mobile
 603         -end_user_phone
 604         end_user_user_id
 605         -end_user_zip_code
 606         enduser_id
 607         libris_enduser_request_id
 608         user
 609         user_id
`
But as they sometimes are missing I did add eval around:

`612 $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });`

` 611     foreach my $field ( @anon_fields ) {
 612         eval {
 613                 $request->illrequestattributes->find({ 'type' => $field })->update({ 'value' => '' });
 614                 1;
 615         };
`
This makes it not create a Server error.