### PR TITLE
Fix reference to non-existent setting from config.yaml

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -1504,7 +1504,7 @@ warn Dumper $params;
         $request->orderid(        $params->{other}->{orderid} );
         $request->borrowernumber( $params->{other}->{borrowernumber} );
         $request->biblio_id(      $other->{biblio_id} );
-        $request->branchcode(     $ill_config->{ 'ill_library' } );
+        $request->branchcode(     $ill_config->{ 'ill_branch' } );
         $request->status(         'IN_UTEL' );
         $request->placed(         DateTime->now);
         $request->medium(         $params->{other}->{medium} );


### PR DESCRIPTION
I've just changed one line. Now as in config.yaml 'ill_branch' instead of 'ill_library'