### PR TITLE
Fix $fee earlier declaration warning

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -672,7 +672,7 @@ sub receive {
 
             my $userenv = C4::Context->userenv;
             my $manager_id = $userenv ? $userenv->{number} : undef;
-            my $fee = Koha::Account::Line->new({
+            $fee = Koha::Account::Line->new({
                 amount            => $fee,
                 borrowernumber    => $request->borrowernumber,
                 debit_type_code   => $debit_type_code,


### PR DESCRIPTION
Logs getting spammed with this warning

"my" variable $fee masks earlier declaration in same scope at /home/koha/Koha/Koha/Illbackends/Libris/Base.pm line 675.