### PR TITLE
Don't update borrowernumber if old illrequest exists

### DIFF
--- a/cron/get_data_from_libris.pl
+++ b/cron/get_data_from_libris.pl
@@ -227,11 +227,16 @@ REQUEST: foreach my $req ( @{ $data->{'ill_requests'} } ) {
 
 ## Save or update the request in Koha
 
+    # Look for the Libris order number
+    my $old_illrequest = Koha::Illrequests->find({ orderid => $req->{'lf_number'} });
+    if ( $old_illrequest and defined $old_illrequest->borrowernumber ) {
+        # Patron is already connected to an old ill request
+        $borrower = Koha::Patrons->find( $old_illrequest->borrowernumber )
+    }
+
     # Home branch of created items
     my $homebranch = $borrower->branchcode;
     my $holdingbranch = $borrower->branchcode;
-    # Look for the Libris order number
-    my $old_illrequest = Koha::Illrequests->find({ orderid => $req->{'lf_number'} });
     # We have an old request, so we update it
     if ( $old_illrequest ) {
         say "Found an existing request with illrequest_id = " . $old_illrequest->illrequest_id if $verbose;


### PR DESCRIPTION
Specification reads "patron’s information before registration of arrival of an inter library loan without the changes later being written over"

Don't update the borrowernumber if an old illrequest exists