### PR TITLE
Bug 33444 compatibility

### DIFF
--- a/Base.pm
+++ b/Base.pm
@@ -1943,10 +1943,12 @@ sub renew {
         })->next;
 
         # Add renew
-        C4::Circulation::AddRenewal(
-            $request->borrowernumber, $checkout->itemnumber,
-            $checkout->branchcode, $due_date
-        );
+        C4::Circulation::AddRenewal({
+            'borrowernumber' => $request->borrowernumber,
+            'itemnumber'     => $checkout->itemnumber,
+            'branch'         => $checkout->branchcode,
+            'datedue'        => $due_date
+        });
 
         # ...then return our result:
         return {


### PR DESCRIPTION
Ciculration::AddRenewal now expects a hashref
from Koha 23.11 onwards.

Test plan:
Attemp "renew" on a 23.11 installation -> error 500 Apply this patch. Repeat. All good.